### PR TITLE
Auto increase offset by 32px when admin bar present

### DIFF
--- a/assets/js/hash-link-scroll-offset.js
+++ b/assets/js/hash-link-scroll-offset.js
@@ -1,4 +1,4 @@
-/*! Hash Link Scroll Offset - v0.1.0 - 2015-04-01
+/*! Hash Link Scroll Offset - v0.1.0 - 2015-04-22
  * http://webdevstudios.com
  * Copyright (c) 2015; * Licensed GPLv2+ */
 /*jslint browser: true */
@@ -8,9 +8,10 @@ window.Hash_Link_Scroll_Offset = (function(window, document, $, undefined){
 	'use strict';
 
 	var app = {};
-	app.offset = window.hashLinkOffset || 0;
 
 	app.init = function() {
+
+		app.offset = app.getOffset();
 
 		// Handle clicking hash links
 		$( 'a[href^="#"]:not(.no-scroll)' ).on( 'click', function() {
@@ -24,6 +25,18 @@ window.Hash_Link_Scroll_Offset = (function(window, document, $, undefined){
 				app.scrollToHash( window.location.hash );
 			}
 		}, 10 );
+
+	};
+
+	app.getOffset = function() {
+		var offset = window.hashLinkOffset || 0;
+
+		// increase the offset by 32px if the WP Admin Bar is present
+		if ( $('#wpadminbar').length ) {
+			offset = ( parseInt( offset, 10 ) + 32 ).toString();
+		}
+
+		return offset;
 
 	};
 

--- a/assets/js/hash-link-scroll-offset.min.js
+++ b/assets/js/hash-link-scroll-offset.min.js
@@ -1,4 +1,4 @@
-/*! Hash Link Scroll Offset - v0.1.0 - 2015-04-01
+/*! Hash Link Scroll Offset - v0.1.0 - 2015-04-22
  * http://webdevstudios.com
  * Copyright (c) 2015; * Licensed GPLv2+ */
-window.Hash_Link_Scroll_Offset=function(o,t,n){"use strict";var s={};return s.offset=o.hashLinkOffset||0,s.init=function(){n('a[href^="#"]:not(.no-scroll)').on("click",function(){s.scrollToHash(this.hash)}),setTimeout(function(){o.location.hash&&(o.scrollTo(0,0),s.scrollToHash(o.location.hash))},10)},s.scrollToHash=function(o){var t=n(o);t.length||(t=n('[name="'+o.substr(1)+'"]')),t.length&&n("html, body").stop().animate({scrollTop:t.offset().top-s.offset},900)},n(t).ready(s.init),s}(window,document,jQuery);
+window.Hash_Link_Scroll_Offset=function(t,o,n){"use strict";var s={};return s.init=function(){s.offset=s.getOffset(),n('a[href^="#"]:not(.no-scroll)').on("click",function(){s.scrollToHash(this.hash)}),setTimeout(function(){t.location.hash&&(t.scrollTo(0,0),s.scrollToHash(t.location.hash))},10)},s.getOffset=function(){var o=t.hashLinkOffset||0;return n("#wpadminbar").length&&(o=""+(parseInt(o,10)+32)),o},s.scrollToHash=function(t){var o=n(t);o.length||(o=n('[name="'+t.substr(1)+'"]')),o.length&&n("html, body").stop().animate({scrollTop:o.offset().top-s.offset},900)},n(o).ready(s.init),s}(window,document,jQuery);

--- a/assets/js/src/hash-link-scroll-offset.js
+++ b/assets/js/src/hash-link-scroll-offset.js
@@ -13,9 +13,10 @@ window.Hash_Link_Scroll_Offset = (function(window, document, $, undefined){
 	'use strict';
 
 	var app = {};
-	app.offset = window.hashLinkOffset || 0;
 
 	app.init = function() {
+
+		app.offset = app.getOffset();
 
 		// Handle clicking hash links
 		$( 'a[href^="#"]:not(.no-scroll)' ).on( 'click', function() {
@@ -29,6 +30,18 @@ window.Hash_Link_Scroll_Offset = (function(window, document, $, undefined){
 				app.scrollToHash( window.location.hash );
 			}
 		}, 10 );
+
+	};
+
+	app.getOffset = function() {
+		var offset = window.hashLinkOffset || 0;
+
+		// increase the offset by 32px if the WP Admin Bar is present
+		if ( $('#wpadminbar').length ) {
+			offset = ( parseInt( offset, 10 ) + 32 ).toString();
+		}
+
+		return offset;
 
 	};
 

--- a/hash-link-scroll-offset.php
+++ b/hash-link-scroll-offset.php
@@ -127,6 +127,7 @@ class Hash_Link_Scroll_Offset {
 		<div class="hash_link_scroll_offset_setting_wrap<?php echo $class; ?>">
 			<input class="small-text" placeholder="50" type="number" step="1" min="1" id="hash_link_scroll_offset" name="hash_link_scroll_offset" value="<?php echo get_option( 'hash_link_scroll_offset', 0 ); ?>"> <?php _e( 'pixels', 'hash_link_scroll_offset' ); ?>
 		</div>
+		<p class="description"><?php _e( 'When the Admin Bar is displayed in your theme, this value is automatically increased by 32px.', 'hash_link_scroll_offset' ); ?></p>
 		<?php
 	}
 


### PR DESCRIPTION
Modify the JavaScript to detect the presence of the WP Admin Bar
and when present increase the offset value by 32px.

Add description to "Hash Link Scroll Offset" setting page to clarify the
value is auto-incremented when the Admin Bar is present.

Fixes #4
