### PR TITLE
Allow scrolling to relative paths

### DIFF
--- a/assets/js/src/hash-link-scroll-offset.js
+++ b/assets/js/src/hash-link-scroll-offset.js
@@ -32,8 +32,14 @@ window.Hash_Link_Scroll_Offset = window.Hash_Link_Scroll_Offset || {};
 		app.$html_and_body = $('html, body');
 
 		// Handle clicking hash links
-		$( 'a[href^="#"]:not(.no-scroll)' ).on( 'click', function( evt ) {
+		$( 'a[href*="#"]:not(.no-scroll)' ).on( 'click', function( evt ) {
 			app.hash = this.hash;
+
+			// If the element doesn't actually exist then bail.
+			if ( ! $( app.hash ) ) {
+				return;
+			}
+
 			app.scrollToHash( app.hash, evt );
 		});
 


### PR DESCRIPTION
Addresses issue #14 by allowing _any_ hash link to match, and then only binding in the case of an element matching the target being on page. 

We may want to consider removing the bail condition all together and leave it up to the browser if there's no target for the hash or if it goes to another page?
