### PR TITLE
Confirmed compatibility with WordPress 6.4

### DIFF
--- a/hash-link-scroll-offset.php
+++ b/hash-link-scroll-offset.php
@@ -3,7 +3,7 @@
  * Plugin Name: Hash Link Scroll Offset
  * Plugin URI:  http://webdevstudios.com
  * Description: Offset the scroll position of anchored links. Handy if you have a sticky header that covers linked material.
- * Version:     0.2.1
+ * Version:     0.2.2
  * Author:      WebDevStudios
  * Author URI:  http://webdevstudios.com
  * Donate link: http://webdevstudios.com

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hash-link-scroll-offset",
   "title": "Hash Link Scroll Offset",
   "description": "Offset the scroll position of anchored links. Handy if you have a sticky header that covers linked material.",
-  "version": "0.1.8",
+  "version": "0.2.2",
   "homepage": "http://webdevstudios.com",
   "author": {
     "name": "WebDevStudios",

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors:      webdevstudios, pluginize
 Donate link:       http://webdevstudios.com
 Tags:
 Requires at least: 5.5
-Tested up to:      6.3
-Stable tag:        0.2.1
+Tested up to:      6.4.3
+Stable tag:        0.2.2
 License:           GPLv2 or later
 License URI:       http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -33,6 +33,9 @@ Use the `no-scroll` class on any hash links that are not meant to scroll to an a
 
 
 == Changelog ==
+
+= 0.2.2 =
+* Confirmed compatibility with WordPress 6.4
 
 = 0.2.1 =
 * Confirmed compatibility with WordPress 6.3


### PR DESCRIPTION
The plugin works correctly with WP 6.4.3 (screenshot with 50 pixels offset). This PR updates the `Tested up to` header comment value.

![Screenshot 2024-02-02 at 9 05 48 AM](https://github.com/WebDevStudios/Hash-Link-Scroll-Offset/assets/117118816/14396749-2ae9-4381-8581-f348746aa611)
